### PR TITLE
Rename Metrics opt-out key

### DIFF
--- a/treble/Settings.bundle/Root.plist
+++ b/treble/Settings.bundle/Root.plist
@@ -16,7 +16,7 @@
 			<key>DefaultValue</key>
 			<true/>
 			<key>Key</key>
-			<string>mapbox_metrics_enabled_preference</string>
+			<string>MGLMapboxMetricsEnabled</string>
 			<key>Title</key>
 			<string>Mapbox Metrics</string>
 			<key>Type</key>


### PR DESCRIPTION
The key was renamed in mapbox/mapbox-gl-native#1480.
